### PR TITLE
Removes option --lossy_8bit from zopflipng call.

### DIFF
--- a/optimage.py
+++ b/optimage.py
@@ -121,6 +121,8 @@ def _call_binary(args):
         raise MissingBinary(error.errno, 'binary not found', args[0])
 
 
+# Add -blacken -bail -l 9
+# and for faster results -l 6 or 7 and maybe -z 2
 def _pngcrush(input_filename, output_filename):
     _call_binary(['pngcrush', '-rem', 'alla', '-reduce', '-brute', '-q',
                   input_filename, output_filename])
@@ -132,8 +134,8 @@ def _optipng(input_filename, output_filename):
 
 
 def _zopflipng(input_filename, output_filename):
-    _call_binary(['zopflipng', '-m', '--lossy_8bit', '--lossy_transparent',
-                  '--filters=0me', input_filename, output_filename])
+    _call_binary(['zopflipng', '-m', '--lossy_transparent', '--filters=0me',
+                  input_filename, output_filename])
 
 
 def _jpegtran(input_filename, output_filename):


### PR DESCRIPTION
Fixes issue #19.

Note that this was not really affecting optimage, as there is a check in place to validate the optimized image is pixel by pixel equivalent to the source.