### PR TITLE
Remove --lossy_8bit from zopflipng call.

### DIFF
--- a/optimage.py
+++ b/optimage.py
@@ -132,8 +132,8 @@ def _optipng(input_filename, output_filename):
 
 
 def _zopflipng(input_filename, output_filename):
-    _call_binary(['zopflipng', '-m', '--lossy_8bit', '--lossy_transparent',
-                  '--filters=0me', input_filename, output_filename])
+    _call_binary(['zopflipng', '-m', '--lossy_transparent', '--filters=0me',
+                  input_filename, output_filename])
 
 
 def _jpegtran(input_filename, output_filename):


### PR DESCRIPTION
Fixes issue #19.

Note that this wasn't really affecting optimage as we have a check in place to validate that the resulting image is pixel by pixel equivalent to the source.