### PR TITLE
Parallelize compressors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     scripts=['scripts/optimage'],
     setup_requires=['pytest-runner'],
     install_requires=['Pillow'],
-    tests_require=['pytest', 'pytest-cov', 'pytest-catchlog'],
+    tests_require=['pytest>=3.3', 'pytest-cov'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Console',

--- a/test_optimage_e2e.py
+++ b/test_optimage_e2e.py
@@ -3,11 +3,6 @@ import shutil
 import subprocess
 
 import pytest
-try:
-  import pytest_catchlog
-  catchlog_available = True
-except ImportError:
-  catchlog_available = False
 
 import optimage
 
@@ -147,8 +142,6 @@ def test_commanderror(capsys, monkeypatch):
     assert 'Output:\ncustom error' in err
 
 
-@pytest.mark.skipif(not catchlog_available,
-                    reason='pytest_catchlog not available')
 @pytest.mark.parametrize('filename, compressor', [
     # Do not specify compressor as it depends on the version of the commands
     # installed. In Mac I get that pngcrush is better than zopflipng, but not in


### PR DESCRIPTION
Compressors can be slow, so it's easy to get a significant speedup by
running compressors in parallel with a thread pool.